### PR TITLE
Fix warnings, adjust coverage and add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/target
+**/*.rs.bk
+Cargo.lock
+.idea
+kcov_output

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 68.2,
+  "coverage_score": 68.8,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/bindings_v5_0_0/mod.rs
+++ b/src/bindings_v5_0_0/mod.rs
@@ -5,6 +5,8 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+// Keep this until https://github.com/rust-lang/rust-bindgen/issues/1651 is fixed.
+#![cfg_attr(test, allow(deref_nullptr, unaligned_references))]
 
 pub mod virtio_blk;
 pub mod virtio_net;


### PR DESCRIPTION
This PR includes the original one from dependabot #33 
It fixes clippy warnings and test coverage due to updated Rust version.